### PR TITLE
[TUNE-14865] Feature: add codec support for HLS (m3u8 and m3u formats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Stop all sounds and reset their seek position to the beginning.
 
 #### codecs(ext)
 Check supported audio codecs. Returns `true` if the codec is supported in the current browser.
-* **ext**: `String` File extension. One of: "mp3", "mpeg", "opus", "ogg", "oga", "wav", "aac", "caf", "m4a", "m4b", "mp4", "weba", "webm", "dolby", "flac".
+* **ext**: `String` File extension. One of: "m3u", "m3u8", "mp3", "mpeg", "opus", "ogg", "oga", "wav", "aac", "caf", "m4a", "m4b", "mp4", "weba", "webm", "dolby", "flac".
 
 #### unload()
 Unload and destroy all currently loaded Howl objects. This will immediately stop all sounds and remove them from cache.


### PR DESCRIPTION
### Issue/Feature
- Add support for HLS file formats m3u8 and m3u.
- Fix bug where codec setup can execute more than once.

### Solution
- Add HLS support via media type defined [here](https://www.iana.org/assignments/media-types/application/vnd.apple.mpegurl).
- Change initial `_codecs` value to null to prevent `_setupCodecs` from executing more than once.

### Reproduction/Testing
Native HLS support in Safari demo: https://codepen.io/jbgomez/pen/GRyPZwv

### Breaking Changes
None.